### PR TITLE
Integrate support for entity class names

### DIFF
--- a/src/Generator/SitemapGenerator.php
+++ b/src/Generator/SitemapGenerator.php
@@ -107,7 +107,7 @@ class SitemapGenerator
     private function saveSitemapForProvider(SitemapProviderInterface $provider): void
     {
         file_put_contents(
-            $this->getPath() . '/sitemap_' . $provider->getKey() . '.xml',
+            $this->getPath() . '/' . $provider->getFilename() . '.xml',
             $this->generateSitemapForProvider($provider)
         );
     }

--- a/src/Provider/SitemapProvider.php
+++ b/src/Provider/SitemapProvider.php
@@ -25,6 +25,19 @@ class SitemapProvider
         return $this->items;
     }
 
+    public function getFilename(): string
+    {
+        $suffix = $this->getKey();
+
+        try {
+            $suffix = (new \ReflectionClass($this->getKey()))->getShortName();
+        } catch (\Exception $e) {
+
+        }
+
+        return 'sitemap_' . $suffix;
+    }
+
     public function getKey(): string
     {
         return $this->key;

--- a/src/Provider/SitemapProvider.php
+++ b/src/Provider/SitemapProvider.php
@@ -27,12 +27,10 @@ class SitemapProvider
 
     public function getFilename(): string
     {
-        $suffix = $this->getKey();
-
         try {
             $suffix = (new \ReflectionClass($this->getKey()))->getShortName();
         } catch (\Exception $e) {
-
+            $suffix = array_pop(explode('\\', $this->getKey()));
         }
 
         return 'sitemap_' . $suffix;

--- a/src/Provider/SitemapProviderInterface.php
+++ b/src/Provider/SitemapProviderInterface.php
@@ -7,8 +7,19 @@ use JeroenDesloovere\SitemapBundle\Item\SitemapItems;
 
 interface SitemapProviderInterface
 {
+    /**
+     * @return string - Must return the wanted filename (without .xml), f.e.: 'sitemap_BlogArticle'
+     */
+    public function getFilename(): string;
+
+    /**
+     * @return string - Must return the Entity class name or a custom name, f.e: 'BlogArticle'
+     */
     public function getKey(): string;
+
     public function getItems(): SitemapItems;
+
     public function createItem(string $url, \DateTime $lastModifiedOn, ChangeFrequency $changeFrequency): void;
+
     public function createItems(): void;
 }

--- a/tests/Generator/SitemapGeneratorTest.php
+++ b/tests/Generator/SitemapGeneratorTest.php
@@ -29,6 +29,7 @@ final class SitemapGeneratorTest extends TestCase
     public function setUp(): void
     {
         $this->providers = new SitemapProviders();
+        $this->providers->add(new TestPageSitemapProvider());
         $this->providers->add(new TestBlogArticleSitemapProvider());
         $this->providers->add(new TestBlogCategorySitemapProvider());
         $this->virtualStorage = vfsStream::setup();
@@ -51,13 +52,14 @@ final class SitemapGeneratorTest extends TestCase
         // Test if generate is working
         $generator->generate();
         $this->assertTrue($this->virtualStorage->hasChild('sitemap.xml'));
+        $this->assertTrue($this->virtualStorage->hasChild('sitemap_Page.xml'));
         $this->assertTrue($this->virtualStorage->hasChild('sitemap_BlogArticle.xml'));
         $this->assertTrue($this->virtualStorage->hasChild('sitemap_BlogCategory.xml'));
     }
 
     public function testItems(): void
     {
-        $this->assertEquals(2, count($this->providers->getAll()));
+        $this->assertEquals(3, count($this->providers->getAll()));
     }
 }
 
@@ -117,4 +119,40 @@ class TestBlogCategorySitemapProvider extends SitemapProvider implements Sitemap
             ]
         ];
     }
+}
+
+class TestPageSitemapProvider extends SitemapProvider implements SitemapProviderInterface
+{
+    public function __construct()
+    {
+        parent::__construct('App\\PagesBundle\\Entity\\Page');
+    }
+
+    public function createItems(): void
+    {
+        foreach ($this->getDummyPages() as $page) {
+            $this->createItem($page['url'], $page['editedOn'], ChangeFrequency::monthly());
+        }
+    }
+
+    private function getDummyPages(): array
+    {
+        return [
+            [
+                'url' => '/nl/first-page',
+                'editedOn' => new \DateTime(),
+            ],
+            [
+                'url' => '/nl/second-page',
+                'editedOn' => new \DateTime(),
+            ]
+        ];
+    }
+}
+
+namespace App\PagesBundle\Entity;
+
+class Page
+{
+    // Empty class for testing
 }


### PR DESCRIPTION
Add fallback when class namespace not exists

`getFilename()` method added in `SitemapProviderInterface`